### PR TITLE
Add reconfiguration for unknown architectures.

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -43,6 +43,20 @@ if [ -n "$CYGWIN_PREFIX" ] ; then
     # msys2 stub libraries for ws2_32.
     platlibs=$(cd $(dirname $(gcc --print-prog-name=ld))/../lib && pwd -W)
     export LDFLAGS="$LDFLAGS -L$platlibs"
+else
+    # for other platforms we just need to reconf to get the correct achitecture
+    echo libtoolize
+    libtoolize
+    echo aclocal -I $PREFIX/share/aclocal -I $BUILD_PREFIX/share/aclocal
+    aclocal -I $PREFIX/share/aclocal -I $BUILD_PREFIX/share/aclocal
+    echo autoheader
+    autoheader
+    echo autoconf
+    autoconf
+    echo automake --force-missing --add-missing --include-deps
+    automake --force-missing --add-missing --include-deps
+
+    export CONFIG_FLAGS="--build=${BUILD}"
 fi
 
 export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,9 @@ build:
 
 requirements:
   build:
+    - autoconf  # [unix]
+    - automake  # [unix]
+    - libtool   # [unix]
     - m2-autoconf  # [win]
     - m2-automake{{ am_version }}  # [win]
     - m2-libtool  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - windows.patch  # [win]
 
 build:
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
 
 requirements:


### PR DESCRIPTION
This PR adds reconfiguration for unknown architectures like `osx-arm64`.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
